### PR TITLE
Use context manager for pdf2docx conversion

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -106,9 +106,8 @@ def convert_file() -> None:
         elif in_ext == "pdf" and out_ext == "docx":
             if PDF2DocxConverter is None:
                 raise RuntimeError("Библиотека pdf2docx не установлена")
-            cv = PDF2DocxConverter(src)
-            cv.convert(dst)
-            cv.close()
+            with PDF2DocxConverter(src) as cv:
+                cv.convert(dst)
         else:
             messagebox.showerror(
                 "Ошибка",


### PR DESCRIPTION
## Summary
- clean up PDF→DOCX conversion by using PDF2DocxConverter as a context manager

## Testing
- `python -m py_compile converter.py`


------
https://chatgpt.com/codex/tasks/task_e_688f39196bb48328935dd4a43dac2b1b